### PR TITLE
Improve top-level exception handling.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,10 @@ apply plugin: 'java'
 apply plugin: 'maven'
 
 group = 'com.fullcontact'
-version = '0.1.3'
+version = '0.2.0'
+
+sourceCompatibility = "1.8";
+targetCompatibility = "1.8";
 
 repositories {
   mavenCentral()


### PR DESCRIPTION
- If interrupted, ensure the interruption state sticks.
- Don't allow any exceptions to propagate out of notify(), instead log
  and swallow them. By default, this goes to stderr, but clients can
  specify their own callbacks.
- Advance to the modern world of Java 8.

@jentfoo 
